### PR TITLE
Remove RNG to debug performance drop with OpenMP

### DIFF
--- a/src/simulation/simulate.cpp
+++ b/src/simulation/simulate.cpp
@@ -389,15 +389,15 @@ std::vector<int> sample_root_states(int num_independent_sites, int num_contactin
         int threadnum = omp_get_thread_num();
         int numthreads = omp_get_num_threads();
         // First sample the independent sites
-        std::discrete_distribution distribution1(cbegin(p1_probability_distribution), cend(p1_probability_distribution));
+        // std::discrete_distribution distribution1(cbegin(p1_probability_distribution), cend(p1_probability_distribution));
         for (int i = threadnum; i < num_independent_sites; i += numthreads) {
-            result[i] = distribution1(random_engines[i]);
+            result[i] = i % 20;  // distribution1(random_engines[i]);
         }
 
         // Then sample the contacting sites
-        std::discrete_distribution distribution2(cbegin(p2_probability_distribution), cend(p2_probability_distribution));
+        // std::discrete_distribution distribution2(cbegin(p2_probability_distribution), cend(p2_probability_distribution));
         for (int j = threadnum; j + 1 < num_contacting_pairs; j += numthreads) {
-            result[num_independent_sites + j] = distribution2(random_engines[num_independent_sites + j]);
+            result[num_independent_sites + j] = j % 20; // distribution2(random_engines[num_independent_sites + j]);
         }
     }
 
@@ -420,8 +420,8 @@ int sample_transition(int index, int starting_state, float elapsed_time, std::st
             current_rate = - Q2_rate_matrix[current_state][current_state];
         }
         // See when the next transition happens
-        std::exponential_distribution<float> distribution1(current_rate);
-        float waiting_time = distribution1(random_engines[index]);
+        // std::exponential_distribution<float> distribution1(current_rate);
+        float waiting_time = current_rate; // distribution1(random_engines[index]);
         current_time += waiting_time;
         if (current_time >= elapsed_time) {
             // We reached the end of the process
@@ -435,8 +435,8 @@ int sample_transition(int index, int starting_state, float elapsed_time, std::st
             rate_vector = Q2_rate_matrix[current_state];
         }
         rate_vector.erase(rate_vector.begin() + current_state);
-        std::discrete_distribution distribution2(cbegin(rate_vector), cend(rate_vector));
-        int new_state = distribution2(random_engines[index]);
+        // std::discrete_distribution distribution2(cbegin(rate_vector), cend(rate_vector));
+        int new_state = (current_state + 1) % 19; // distribution2(random_engines[index]);
         if (new_state >= current_state) {
             new_state += 1;
         }

--- a/src/simulation/simulate.cpp
+++ b/src/simulation/simulate.cpp
@@ -396,7 +396,7 @@ std::vector<int> sample_root_states(int num_independent_sites, int num_contactin
 
         // Then sample the contacting sites
         // std::discrete_distribution distribution2(cbegin(p2_probability_distribution), cend(p2_probability_distribution));
-        for (int j = threadnum; j + 1 < num_contacting_pairs; j += numthreads) {
+        for (int j = threadnum; j < num_contacting_pairs; j += numthreads) {
             result[num_independent_sites + j] = j % 20; // distribution2(random_engines[num_independent_sites + j]);
         }
     }


### PR DESCRIPTION
This seems to give a reproducible segfault:
```
export OMP_NUM_THREADS=4 && export OMP_PLACES=cores && export OMP_PROC_BIND=spread &&     srun -t 00:20:00 --cpu_bind=cores -C knl -N 1 --ntasks-per-node=16 src/simulation/simulate     /global/cscratch1/sd/sprillo/cs267_data_strip//trees_1024_seqs_None_sites_LG_FastTree.txt-d15ceeb4_RM_20_cats     /global/cscratch1/sd/sprillo/cs267_data_strip//site_rates_1024_seqs_None_sites_LG_FastTree.txt-d15ceeb4_RM_20_cats     /global/cscratch1/sd/sprillo/cs267_data_strip//contact_maps_1024_seqs_None_sites_LG_FastTree.txt-d15ceeb4_RM_20_cats_maximal_matching     256     20     data/rate_matrices/wag_stationary.txt     data/rate_matrices/wag.txt     data/rate_matrices/wag_x_wag_stationary.txt     data/rate_matrices/wag_x_wag.txt     all_transitions     /global/cscratch1/sd/sprillo/benchmarking_simulation_output     0     13gs_1_A 19hc_1_A 1a0b_1_A 1a0p_1_A 1a0t_1_A 1a12_1_A 1a17_1_A 1a27_1_A 1a2o_1_A 1a2t_1_A 1a3a_1_A 1a40_1_A 1a41_1_A 1a45_1_A 1a4a_1_A 1a4m_1_A 1a4p_1_A 1a5k_1_B 1a5t_1_B 1a62_1_A 1a64_1_A 1a6l_1_A 1a6q_1_A 1a79_1_A 1a7j_1_A 1a82_1_A 1a8h_1_A 1a8l_1_A 1a8m_1_A 1a92_1_A 1a95_1_B 1a9y_1_A 1aac_1_A 1aba_1_A 1ac5_1_A 1acf_1_A 1aco_1_A 1acx_1_A 1ae9_1_A 1af2_1_A 1af6_1_A 1agj_1_A 1ah7_1_A 1ais_1_B 1ajc_1_B 1ajo_1_A 1ak0_1_A 1alu_1_A 1am2_1_B 1am7_1_A 1am9_1_C 1amp_1_A 1amu_1_A 1amx_1_A 1aoa_1_A 1aoj_1_A 1aom_1_B 1aoz_1_A 1aq6_1_A 1aqc_1_B 1ash_1_A 1at0_1_B 1atg_1_A 1aua_1_B 1auq_1_A 1ava_1_A 1avy_1_A 1aw7_1_A 1ax8_1_A 1axi_1_B 1axk_1_A 1aye_1_A 1ayo_1_B 1az3_1_A 1az5_1_B 1azo_1_A 1b02_1_A 1b0n_1_A 1b0p_1_A 1b11_1_A 1b25_1_A 1b2v_1_A 1b33_1_A 1b33_1_G 1b42_1_A 1b4a_1_A 1b4f_1_B 1b4u_1_A 1b4u_1_B 1b55_1_D 1b5d_1_A 1b5f_1_C 1b5f_1_D 1b5l_1_A 1b5q_1_A 1b66_1_A 1b6b_1_A 1b71_1_A 1b79_1_B 1b7y_1_C 1b82_1_A 1b8g_1_B 1b8p_1_A 1b90_1_A 1b94_1_A 1b9n_1_B 1bai_1_A 1bb9_1_B 1bbr_1_C 1bc5_1_A 1bcg_1_A 1bco_1_A 1bcs_1_B 1bdo_1_A 1bdy_1_B 1be0_1_A 1bed_1_B 1bf2_1_A 1bfa_1_A 1bg1_1_B 1bg6_1_B 1bgv_1_A 1bh3_1_A 1bhe_1_A 1bhj_1_A 1bht_1_A 1bia_1_A 1bik_1_A 1bja_1_A 1bjt_1_B 1bkj_1_A 1bkr_1_A 1bm9_1_A 1bnd_1_A 1bob_1_A 1boz_1_A 1bpl_1_A 1bpl_1_B 1bqb_1_A 1bqp_1_A 1bqu_1_B 1bsl_1_B 1bte_1_A 1btn_1_B 1bv4_1_C 1bvn_1_A 1bvy_1_C 1bw0_1_A 1bw9_1_A 1bwv_1_E 1bx7_1_A 1bxi_1_A 1bxr_1_A 1bxw_1_A 1bxy_1_B 1byf_1_A 1byl_1_A 1byr_1_A 1byu_1_B 1bz4_1_A 1bzd_1_A 1bzy_1_A 1c0i_1_A 1c1k_1_A 1c25_1_A 1c28_1_C 1c3f_1_A 1c4w_1_A 1c52_1_A 1c5e_1_A 1c75_1_A 1c7s_1_A 1c80_1_A 1c8z_1_A 1c9k_1_B 1ca9_1_A 1cau_1_A 1cau_1_B 1cb7_1_A 1cb7_1_B 1cb8_1_A 1ccz_1_A 1cd5_1_A 1cdg_1_A 1cen_1_A 1cez_1_A 1cf2_1_A 1cfb_1_A 1cg2_1_A 1chk_1_A 1chm_1_B 1ci3_1_A 1ci4_1_A 1ci8_1_A 1cia_1_A 1cjs_1_A 1cjx_1_A 1cjy_1_A 1ckn_1_A 1ckq_1_A 1cks_1_B 1clk_1_A 1cm5_1_A 1cmb_1_A 1cmx_1_C 1cnt_1_B 1co7_1_B 1col_1_A 1coz_1_A 1cp9_1_A 1cpn_1_A 1cpt_1_A 1cqy_1_A 1cr1_1_A 1cr5_1_A 1csb_1_A 1csb_1_B 1csm_1_A 1ct9_1_B 1ctf_1_B 1cun_1_A 1cvm_1_A 1cwq_1_A 1cwv_1_A 1cwy_1_A 1cxz_1_B 1cy9_1_B 1cyw_1_A 1cz1_1_A 1cz3_1_A 1d0g_1_E 1d0n_1_A 1d0q_1_B 1d2o_1_B 1d2p_1_A 1d2z_1_A 1d2z_1_B 1d3b_1_A 1d3y_1_A 1d5t_1_A 1d7c_1_A 1d8h_1_A 1d8l_1_A 1d9c_1_B 1dab_1_A 1db3_1_B 1dbg_1_A 1dbh_1_A 1dbi_1_A 1dbx_1_A 1dc1_1_A 1dce_1_A 1dcf_1_B 1dcn_1_B 1dd3_1_A 1dd4_1_D     A R N D C Q E G H I L K M F P S T W Y V
```