### PR TITLE
[DON'T MERGE] Xingyu simulation bugfixed

### DIFF
--- a/src/simulation/simulate.cpp
+++ b/src/simulation/simulate.cpp
@@ -553,11 +553,11 @@ void run_simulation(std::string tree_dir, std::string site_rates_dir, std::strin
 
         // Sample all the transitions for this node
         // First sample the independent sites
-        // #pragma omp parallel for schedule(dynamic)
-        for (int i = 0; i < num_independent_sites; i++) {
-            int starting_state = parent_states_int[i];
-            float elapsed_time = parent_pair_length * site_rates[independent_sites[i]];
-            node_states_int[i] = sample_transition(i, starting_state, elapsed_time, strategy, true);
+        #pragma omp parallel for schedule(dynamic)
+        for (int j = 0; j < num_independent_sites; j++) {
+            int starting_state = parent_states_int[j];
+            float elapsed_time = parent_pair_length * site_rates[independent_sites[j]];
+            node_states_int[j] = sample_transition(j, starting_state, elapsed_time, strategy, true);
         }
         // Then sample the contacting sites
         #pragma omp parallel for schedule(dynamic)

--- a/src/simulation/simulate.cpp
+++ b/src/simulation/simulate.cpp
@@ -56,6 +56,8 @@ std::vector<std::string> amino_acids_alphabet;
 std::vector<std::string> amino_acids_pairs;
 std::default_random_engine* random_engines;
 
+#define DEBUG 0
+
 // Adjacent value pairs
 typedef struct {
     /* data */
@@ -694,19 +696,24 @@ int main(int argc, char *argv[]) {
 
 
     // Run the simulation for all the families assigned to the process
-    std::string msg;
-    for (std::string family : local_families) {
-        msg += " " + family;
+    if(DEBUG){
+        std::string msg;
+        for (std::string family : local_families) {
+            msg += " " + family;
+        }
+        std::cerr << "my families are: " << msg << std::endl;
     }
-    std::cerr << "my families are: " << msg << std::endl;
     for (std::string family : local_families) {
-        std::cerr << "Running on family " << family << std::endl;
+        if(DEBUG)
+            std::cerr << "Running on family " << family << std::endl;
         run_simulation(tree_dir, site_rates_dir, contact_map_dir, output_msa_dir, family, random_seed + rank, strategy);
     }
     
-    std::cerr << "Waiting on barrier" << std::endl;
+    if(DEBUG)
+        std::cerr << "Waiting on barrier" << std::endl;
     MPI_Barrier(MPI_COMM_WORLD);
-    std::cerr << "Outside barrier" << std::endl;
+    if(DEBUG)
+        std::cerr << "Outside barrier" << std::endl;
 
     auto end_sim = std::chrono::high_resolution_clock::now();
     double sim_time = std::chrono::duration<double>(end_sim - end_init).count();
@@ -719,7 +726,9 @@ int main(int argc, char *argv[]) {
         outprofilingfile.close();
     }
 
-    std::cerr << "Finalizing" << std::endl;
+    if(DEBUG)
+        std::cerr << "Finalizing" << std::endl;
     MPI_Finalize();
-    std::cerr << "Finalized!!!" << std::endl;
+    if(DEBUG)
+        std::cerr << "Finalized!!!" << std::endl;
 }

--- a/tests/simulation_tests/simulation_test.py
+++ b/tests/simulation_tests/simulation_test.py
@@ -72,6 +72,7 @@ class TestSimulation(unittest.TestCase):
         families = ["fam1", "fam2", "fam3"]
         tree_dir = "./tests/simulation_tests/test_input_data/tree_dir"
         with tempfile.TemporaryDirectory() as synthetic_contact_map_dir:
+            synthetic_contact_map_dir = "tests/simulation_tests/test_input_data/synthetic_contact_map_dir"
             # Create synthetic contact maps
             contact_maps = {}
             for i, family in enumerate(families):
@@ -89,6 +90,7 @@ class TestSimulation(unittest.TestCase):
                 contact_maps[family] = contact_map
 
             with tempfile.TemporaryDirectory() as synthetic_site_rates_dir:
+                synthetic_site_rates_dir = "tests/simulation_tests/test_input_data/synthetic_site_rates_dir"
                 for i, family in enumerate(families):
                     site_rates = [1.0 * np.log(1 + i) for i in range(num_sites)]
                     site_rates_path = os.path.join(
@@ -97,6 +99,7 @@ class TestSimulation(unittest.TestCase):
                     write_site_rates(site_rates, site_rates_path)
 
                 with tempfile.TemporaryDirectory() as simulated_msa_dir:
+                    simulated_msa_dir = "tests/simulation_tests/test_input_data/simulated_msa_dir"
                     simulate_msas(
                         tree_dir=tree_dir,
                         site_rates_dir=synthetic_site_rates_dir,
@@ -171,9 +174,7 @@ class TestSimulation(unittest.TestCase):
         families = ["fam1", "fam2", "fam3"]
         tree_dir = "./tests/simulation_tests/test_input_data/tree_dir"
         with tempfile.TemporaryDirectory() as synthetic_contact_map_dir:
-        # if True:
-        #     synthetic_contact_map_dir = "./tests/simulation_tests/test_input_data/synthetic_contact_map_dir"
-            # Create synthetic contact maps
+            synthetic_contact_map_dir = "tests/simulation_tests/test_input_data/synthetic_contact_map_dir"
             contact_maps = {}
             for i, family in enumerate(families):
                 num_sites = 1000
@@ -190,8 +191,7 @@ class TestSimulation(unittest.TestCase):
                 contact_maps[family] = contact_map
 
             with tempfile.TemporaryDirectory() as synthetic_site_rates_dir:
-            # if True:
-            #     synthetic_site_rates_dir = "./tests/simulation_tests/test_input_data/synthetic_site_rates_dir"
+                synthetic_site_rates_dir = "tests/simulation_tests/test_input_data/synthetic_site_rates_dir"
                 for i, family in enumerate(families):
                     site_rates = [1.0 * np.log(1 + i) for i in range(num_sites)]
                     site_rates_path = os.path.join(
@@ -200,8 +200,7 @@ class TestSimulation(unittest.TestCase):
                     write_site_rates(site_rates, site_rates_path)
 
                 with tempfile.TemporaryDirectory() as simulated_msa_dir:
-                # if True:
-                #     simulated_msa_dir = "./tests/simulation_tests/test_input_data/simulated_msa_dir"
+                    simulated_msa_dir = "tests/simulation_tests/test_input_data/simulated_msa_dir"
                     simulate_msas(
                         tree_dir=tree_dir,
                         site_rates_dir=synthetic_site_rates_dir,


### PR DESCRIPTION
This just illustrates how I fixed the OpenMP race condition on std::vectors in the simulation code. I removed all the omp parallel for except the most important one. And for that one, I just changed all vectors being written (and read, just in case) by arrays.